### PR TITLE
Decorate serverless functions

### DIFF
--- a/src/main/java/at/uibk/dps/ee/enactables/serverless/FunctionFactoryServerless.java
+++ b/src/main/java/at/uibk/dps/ee/enactables/serverless/FunctionFactoryServerless.java
@@ -25,7 +25,7 @@ public class FunctionFactoryServerless extends FunctionFactory {
    *        wrap the created functions
    */
   @Inject
-  public FunctionFactoryServerless(Set<FunctionDecoratorFactory> decoratorFactories) {
+  public FunctionFactoryServerless(final Set<FunctionDecoratorFactory> decoratorFactories) {
     super(decoratorFactories);
   }
 

--- a/src/main/java/at/uibk/dps/ee/enactables/serverless/FunctionFactoryServerless.java
+++ b/src/main/java/at/uibk/dps/ee/enactables/serverless/FunctionFactoryServerless.java
@@ -1,27 +1,44 @@
 package at.uibk.dps.ee.enactables.serverless;
 
 import at.uibk.dps.ee.core.enactable.EnactmentFunction;
+import at.uibk.dps.ee.core.enactable.FunctionDecoratorFactory;
+import at.uibk.dps.ee.enactables.FunctionFactory;
 import net.sf.opendse.model.Mapping;
 import net.sf.opendse.model.Resource;
 import net.sf.opendse.model.Task;
 
+import javax.inject.Inject;
+import java.util.Set;
+
 /**
  * The {@link FunctionFactoryServerless} creates the {@link EnactmentFunction}s
  * modeling the enactment of a serverless function.
- * 
+ *
  * @author Fedor Smirnov
  */
-public class FunctionFactoryServerless {
+public class FunctionFactoryServerless extends FunctionFactory {
+
+  /**
+   * Injection constructor.
+   *
+   * @param decoratorFactories the factories for the decorators which are used to
+   *        wrap the created functions
+   */
+  @Inject
+  public FunctionFactoryServerless(Set<FunctionDecoratorFactory> decoratorFactories) {
+    super(decoratorFactories);
+  }
 
   /**
    * Creates the {@link ServerlessFunction} which is modeled by the provided
-   * resource node.
-   * 
+   * resource node, decorated with the injected decorators.
+   *
    * @param mapping the provided mapping edge
    * @return the {@link ServerlessFunction} which is modeled by the provided
-   *         resource node
+   *         resource node, decorated with the injected decorators
    */
   public EnactmentFunction createServerlessFunction(final Mapping<Task, Resource> mapping) {
-    return new ServerlessFunction(mapping);
+    final EnactmentFunction serverlessFunction = new ServerlessFunction(mapping);
+    return decorate(serverlessFunction);
   }
 }

--- a/src/test/java/at/uibk/dps/ee/enactables/serverless/FunctionFactoryServerlessTest.java
+++ b/src/test/java/at/uibk/dps/ee/enactables/serverless/FunctionFactoryServerlessTest.java
@@ -11,11 +11,13 @@ import net.sf.opendse.model.Mapping;
 import net.sf.opendse.model.Resource;
 import net.sf.opendse.model.Task;
 
+import java.util.HashSet;
+
 public class FunctionFactoryServerlessTest {
 
   @Test
   public void test() {
-    FunctionFactoryServerless tested = new FunctionFactoryServerless();
+    FunctionFactoryServerless tested = new FunctionFactoryServerless(new HashSet<>());
     Resource slRes = PropertyServiceResourceServerless.createServerlessResource("res", "link");
     Task task = PropertyServiceFunctionUser.createUserTask("task", "addition");
     Mapping<Task, Resource> mapping =


### PR DESCRIPTION
This PR adds the functionality to decorate serverless functions. Analog to the implementation in the `FunctionFactoryLocal`, the `FunctionFactoryServerless`  also decorates the created `ServerlessFunction` with the injected decorators before returning them. 

This allows us to use the decorators for both local and serverless functions.